### PR TITLE
Response with status 0 is not successful

### DIFF
--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -19,7 +19,7 @@ class Response extends AbstractResponse
 
 
         $this->data = array();
-        if ($data && count($data)) {
+        if ($data && strlen($data)) {
             parse_str($data, $this->data);
         } else {
             throw new InvalidResponseException();

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -29,7 +29,7 @@ class Response extends AbstractResponse
 
     public function isSuccessful()
     {
-        return isset($this->data['STATUS']) && ('0' === $this->data['STATUS'] || '1' === $this->data['STATUS']);
+        return isset($this->data['STATUS']) && ('1' === $this->data['STATUS']);
     }
 
 


### PR DESCRIPTION
There's two issues here:

- `count($data)` throws a warning in PHP 7.2. `strlen($data)` seems more appropriate, as `$data` can be cast into string
- According to BluePay's documentation, `STATUS == 0` means the transaction was declined. This library treats declined payments as successful. 

> STATUS
  Code for the final status of the transaction. 1 for approved, 0 for declined or E for error.
https://www.bluepay.com/sites/default/files/documentation/BluePay_bp10emu/BluePay%201-0%20Emulator.txt