### PR TITLE
Updated code for Omnipay 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 [Omnipay](https://github.com/omnipay/omnipay) is a framework agnostic, multi-gateway payment
 processing library for PHP 5.3+. This package implements BluePay support for Omnipay.
 
+This build is a fork of the package from https://github.com/zburke/omnipay-bluepay
+
 ## Installation
 
 Omnipay is installed via [Composer](http://getcomposer.org/). To install, simply add it
@@ -15,7 +17,7 @@ to your `composer.json` file:
 ```json
 {
     "require": {
-        "emergingdzns/omnipay-bluepay": "~1.0"
+        "emergingdzns/omnipay-bluepay": "~2.0"
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **BluePay driver for the Omnipay PHP payment processing library**
 
-[![Build Status](https://travis-ci.org/zburke/omnipay-bluepay.png?branch=master)](https://travis-ci.org/zburke/omnipay-bluepay)
+[![Build Status](https://travis-ci.org/emergingdzns/omnipay-bluepay.png?branch=master)](https://travis-ci.org/emergingdzns/omnipay-bluepay)
 
 [Omnipay](https://github.com/omnipay/omnipay) is a framework agnostic, multi-gateway payment
 processing library for PHP 5.3+. This package implements BluePay support for Omnipay.
@@ -15,7 +15,7 @@ to your `composer.json` file:
 ```json
 {
     "require": {
-        "zburke/omnipay-bluepay": "~1.0"
+        "emergingdzns/omnipay-bluepay": "~1.0"
     }
 }
 ```
@@ -44,5 +44,5 @@ If you want to keep up to date with release anouncements, discuss ideas for the 
 or ask more detailed questions, there is also a [mailing list](https://groups.google.com/forum/#!forum/omnipay) which
 you can subscribe to.
 
-If you believe you have found a bug, please report it using the [GitHub issue tracker](https://github.com/zburke/omnipay-bluepay/issues),
+If you believe you have found a bug, please report it using the [GitHub issue tracker](https://github.com/emergingdzns/omnipay-bluepay/issues),
 or better yet, fork the library and submit a pull request.

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "zburke/omnipay-bluepay",
+    "name": "emergingdzns/omnipay-bluepay",
     "type": "library",
     "description": "BluePay gateway for the Omnipay payment processing library",
     "keywords": [
@@ -10,7 +10,7 @@
         "pay",
         "payment"
     ],
-    "homepage": "https://github.com/zburke/omnipay-bluepay",
+    "homepage": "https://github.com/emergingdzns/omnipay-bluepay",
     "license": "MIT",
     "authors": [
         {
@@ -19,17 +19,17 @@
         },
         {
             "name": "Omnipay Contributors",
-            "homepage": "https://github.com/zburke/omnipay-bluepay/contributors"
+            "homepage": "https://github.com/emergingdzns/omnipay-bluepay/contributors"
         }
     ],
     "autoload": {
         "psr-4": { "Omnipay\\BluePay\\" : "src/" }
     },
     "require": {
-        "omnipay/common": "~2.0"
+        "omnipay/common": "~3"
     },
     "require-dev": {
-        "omnipay/tests": "~2.0"
+        "omnipay/tests": "~3"
     },
     "extra": {
         "branch-alias": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,9 +14,6 @@
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-    <listeners>
-        <listener class="Mockery\Adapter\Phpunit\TestListener" file="vendor/mockery/mockery/library/Mockery/Adapter/Phpunit/TestListener.php" />
-    </listeners>
     <filter>
         <whitelist>
             <directory>./src</directory>

--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -37,6 +37,10 @@ class Gateway extends AbstractGateway
         );
     }
 
+    public function setCard($value)
+    {
+        return $this->setParameter('card', $value);
+    }
 
     public function getAccountId()
     {

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -185,18 +185,8 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
 
     public function sendData($data)
     {
-        // don't throw exceptions for 4xx errors
-        // cribbed from https://github.com/thephpleague/omnipay-stripe/blob/master/src/Message/AbstractRequest.php
         // Fist add in my tamper-proof-seal
         $data = array_merge($data, $this->tps($data));
-        $this->httpClient->getEventDispatcher()->addListener(
-            'request.error',
-            function ($event) {
-                if ($event['response']->isClientError()) {
-                    $event->stopPropagation();
-                }
-            }
-        );
 
         $httpResponse = $this->httpClient->post($this->getEndpoint(), [], http_build_query($data));
         return $this->response = new Response($this, $httpResponse->getBody()->getContents());

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Log;
 namespace Omnipay\BluePay\Message;
 
 /**
@@ -34,7 +35,6 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     {
         return $this->setParameter('secretKey', $value);
     }
-
 
     public function getToken()
     {
@@ -188,7 +188,8 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         // Fist add in my tamper-proof-seal
         $data = array_merge($data, $this->tps($data));
 
-        $httpResponse = $this->httpClient->request('POST',$this->getEndpoint(), [], http_build_query($data));
+        $httpResponse = $this->httpClient->request('POST', $this->getEndpoint(), [], http_build_query($data));
+
         return $this->response = new Response($this, $httpResponse->getBody()->getContents());
     }
 

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -198,8 +198,8 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
             }
         );
 
-        $httpResponse = $this->httpClient->post($this->getEndpoint(), null, $data)->send();
-        return $this->response = new Response($this, $httpResponse->getBody());
+        $httpResponse = $this->httpClient->post($this->getEndpoint(), [], http_build_query($data));
+        return $this->response = new Response($this, $httpResponse->getBody()->getContents());
     }
 
 

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -188,7 +188,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         // Fist add in my tamper-proof-seal
         $data = array_merge($data, $this->tps($data));
 
-        $httpResponse = $this->httpClient->post($this->getEndpoint(), [], http_build_query($data));
+        $httpResponse = $this->httpClient->request('POST',$this->getEndpoint(), [], http_build_query($data));
         return $this->response = new Response($this, $httpResponse->getBody()->getContents());
     }
 

--- a/src/Message/RefundRequest.php
+++ b/src/Message/RefundRequest.php
@@ -11,6 +11,7 @@ class RefundRequest extends AbstractRequest
 
     public function getData()
     {
+
         $this->validate('transactionReference', 'amount');
 
         $data = $this->getBaseData();

--- a/src/Message/RefundRequest.php
+++ b/src/Message/RefundRequest.php
@@ -11,12 +11,10 @@ class RefundRequest extends AbstractRequest
 
     public function getData()
     {
-        $this->getCard()->validate();
+        $this->validate('transactionReference', 'amount');
 
         $data = $this->getBaseData();
-        $data['PAYMENT_ACCOUNT'] = $this->getCard()->getNumber();
-        $data['CARD_EXPIRE'] = $this->getCard()->getExpiryDate('my');
-        $data['CARD_CVV2'] = $this->getCard()->getCvv();
+        $data['MASTER_ID'] = $this->getParameter('transactionReference');
 
         return array_merge($data, $this->getBillingData());
     }


### PR DESCRIPTION
I modified the composer file and readme to reference my repo for my own testing and development (global find/replace). Feel free to ignore those changes. The only changes in the composer.json you need to keep are the require and require dev omnipay version numbers.

In the readme you have the instruction to require version 1.0. I changed it to 2.0.

Otherwise very little needed to be changed. Omnipay 3 no longer uses Guzzle so the 404 error check is unnecessary in the AbstractRequest sendData method.

Also the send data is now `$this->httpClient->request('POST',$this->getEndpoint(), [], http_build_query($data));` instead of the old `->post()` method due to the change in client library.

In the phpunit xml file the Mockery listener is removed per the Omnipay upgrade documentation.

To be honest, I have no idea how to run the unit tests nor how to edit the tests to adjust to the changes (if they even need to be changed).